### PR TITLE
61 RCS and RS app config for docker

### DIFF
--- a/docker/securebanking-openbanking-uk-rcs.yml
+++ b/docker/securebanking-openbanking-uk-rcs.yml
@@ -1,0 +1,27 @@
+### Spring Configuration for securebanking-openbanking-uk-rcs running in Docker
+
+rcs:
+  issuerId: forgerock-rcs
+
+rs:
+  internal-port: 8082
+  base-url: http://localhost:${rs.internal-port}
+
+idm:
+  internal-port: 8083
+  base-url: http://wiremock:${idm.internal-port}
+
+jwkms:
+  internal-port: 8083
+  base-url: http://wiremock:${jwkms.internal-port}
+
+am:
+  root: http://wiremock:8083
+  cookie:
+    name: iPlanetDirectoryPro
+  oidc:
+    issuerid: ${am.root}/oauth2
+  userprofile:
+    id: id
+  endpoint:
+    userprofile: ${am.root}/userprofile

--- a/docker/securebanking-openbanking-uk-rcs.yml
+++ b/docker/securebanking-openbanking-uk-rcs.yml
@@ -1,22 +1,43 @@
+#
+# Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ### Spring Configuration for securebanking-openbanking-uk-rcs running in Docker
+
+logging:
+  level:
+    com.forgerock: DEBUG
 
 rcs:
   issuerId: forgerock-rcs
 
 rs:
-  internal-port: 8082
-  base-url: http://localhost:${rs.internal-port}
+  internal-port: 8080
+  base-url: http://rs-simulator:${rs.internal-port}
 
 idm:
-  internal-port: 8083
-  base-url: http://wiremock:${idm.internal-port}
+  internal-port: 9080
+  base-url: http://wiremock:${idm.internal-port}/idm
 
 jwkms:
-  internal-port: 8083
-  base-url: http://wiremock:${jwkms.internal-port}
+  internal-port: 9080
+  base-url: http://wiremock:${jwkms.internal-port}/jwkms
 
 am:
-  root: http://wiremock:8083
+  hostname: am
+  root: http://wiremock:9080/${am.hostname}
   cookie:
     name: iPlanetDirectoryPro
   oidc:
@@ -25,3 +46,4 @@ am:
     id: id
   endpoint:
     userprofile: ${am.root}/userprofile
+    authorize: ${am.root}/oauth2/authorize

--- a/docker/securebanking-openbanking-uk-rs.yml
+++ b/docker/securebanking-openbanking-uk-rs.yml
@@ -1,0 +1,20 @@
+### Spring Configuration for securebanking-openbanking-uk-rs-simulator running in Docker
+
+# Spring data Mongo config - TODO provide credentials securely for each env
+spring:
+  data:
+    mongodb:
+      database: mongo
+
+rs:
+  # TODO - what should this be? OB uses https://matls.rs.aspsp
+  baseUrl: http://localhost:8080
+  discovery:
+    financialId: 0015800001041REAAY
+
+  # Data creation limits (see com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.DataCreator)
+  data:
+    upload:
+      limit:
+        accounts: 100
+        documents: 1000

--- a/docker/securebanking-openbanking-uk-rs.yml
+++ b/docker/securebanking-openbanking-uk-rs.yml
@@ -1,13 +1,33 @@
+#
+# Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ### Spring Configuration for securebanking-openbanking-uk-rs-simulator running in Docker
 
-# Spring data Mongo config - TODO provide credentials securely for each env
+logging:
+  level:
+    com.forgerock: DEBUG
+
+# Spring data Mongo config
 spring:
   data:
     mongodb:
       database: mongo
 
+# RS config
 rs:
-  # TODO - what should this be? OB uses https://matls.rs.aspsp
   baseUrl: http://localhost:8080
   discovery:
     financialId: 0015800001041REAAY


### PR DESCRIPTION
RCS and RS config for docker (when using git, rather than the "native" file profile).

This approach allows us to have application config in separate folders, such as docker, test, production etc. We can split them up further by application if the need arises.